### PR TITLE
Fix Linux upside-down flickering bug

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -67,7 +67,6 @@ class _ChatPageState extends State<ChatPage> {
   final ScrollController _scrollController = ScrollController();
   final List<Map<String, dynamic>> _messages = [];
   String? _gifPath;
-  int? _gifCacheWidth;
   ValueNotifier<String>? _currentReplyNotifier;
   bool _stopRequested = false;
 
@@ -294,30 +293,20 @@ class _ChatPageState extends State<ChatPage> {
     final topPadding = MediaQuery.paddingOf(context).top + _topSettingsReserve;
     final bottomPadding =
         MediaQuery.paddingOf(context).bottom + _bottomPromptReserve;
-    final dpr = MediaQuery.devicePixelRatioOf(context);
-    final cacheWidth = (MediaQuery.sizeOf(context).width * dpr).round();
     Widget image;
     if (filePath != null) {
-      if (_gifCacheWidth != cacheWidth) {
-        _gifCacheWidth = cacheWidth;
-      }
       image = Image.file(
         File(filePath),
         fit: BoxFit.cover,
         gaplessPlayback: true,
         filterQuality: FilterQuality.low,
-        cacheWidth: _gifCacheWidth,
       );
     } else {
-      if (_gifCacheWidth != cacheWidth) {
-        _gifCacheWidth = cacheWidth;
-      }
       image = Image.asset(
         'assets/gifs/${_state.defaultFileName}',
         fit: BoxFit.cover,
         gaplessPlayback: true,
         filterQuality: FilterQuality.low,
-        cacheWidth: _gifCacheWidth,
       );
     }
     return Padding(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -348,10 +348,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
@@ -641,10 +641,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.9"
   typed_data:
     dependency: transitive
     description:


### PR DESCRIPTION
Fixed the upside down and flickering UI issue on Linux. The problem was traced to how Flutter's engine handles the decoding and resizing of animated GIFs when `cacheWidth` is used, triggering an OpenGL origin flip bug on certain setups. Removing `cacheWidth` from both `Image.file` and `Image.asset` widgets fixes this rendering bug. Tests continue to pass successfully.

---
*PR created automatically by Jules for task [4148984749146744139](https://jules.google.com/task/4148984749146744139) started by @alfuentes123*